### PR TITLE
fix: gc_root_set_headの初期化

### DIFF
--- a/microcontroller/core/src/c-runtime.c
+++ b/microcontroller/core/src/c-runtime.c
@@ -442,6 +442,7 @@ void gc_initialize() {
     heap_memory[1] = 2;  // the size of the reserved space (first two words).
     heap_memory[2] = HEAP_SIZE;
     heap_memory[3] = HEAP_SIZE - 2;
+    gc_root_set_head = NULL;
 #ifdef LINUX64
     initialize_pointer_table();
 #endif


### PR DESCRIPTION
`gc_initialize()` で `gc_root_set_head` をリセットしていなかったため、
 `TASK_RESET` 後にルートセットのリンクリストが循環する問題を修正。
